### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,28 @@
 CC=gcc
-CFLAGS=-Wall -std=gnu11 -I.
-LDFLAGS=-static -flto -L. -lfftw3f_omp -lfftw3f -lm -lgsl -fopenmp
+CFLAGS= -std=gnu11 -I.
+LDFLAGS= $(RFLAGS) -L. -lfftw3f_omp -lfftw3f -lm -lgsl -fopenmp
 EXECUTABLES= x2kc2c t2wr2c mxyz2muvw avg
-RFLAGS=-O3 -funroll-loops -flto -fwhole-program -march=native
-DFLAGS=-g -O0 -march=sandybridge
+RFLAGS= -O3 -march=native -pipe -flto -funroll-loops
+DFLAGS= -g -Og
 
 all: release
 
 release:
-	$(foreach 	EXECUTABLE,$(EXECUTABLES),$(CC) $(CFLAGS) $(RFLAGS) $(EXECUTABLE).c core/*.c -o $(EXECUTABLE) $(LDFLAGS) &&) true
+        $(foreach       EXECUTABLE,$(EXECUTABLES),$(CC) $(CFLAGS) $(RFLAGS) $(EXECUTABLE).c core/*.c -o $(EXECUTABLE) $(LDFLAGS) &&) true
 
 valgrind:
-	$(foreach 	EXECUTABLE,$(EXECUTABLES),$(CC) $(CFLAGS) $(DFLAGS) $(EXECUTABLE).c core/*.c -o $(EXECUTABLE) $(LDFLAGS) &&) true
+        $(foreach       EXECUTABLE,$(EXECUTABLES),$(CC) $(CFLAGS) $(DFLAGS) $(EXECUTABLE).c core/*.c -o $(EXECUTABLE) $(LDFLAGS) &&) true
 
 sanitizer:
-	$(foreach 	EXECUTABLE,$(EXECUTABLES),$(CC) $(CFLAGS) $(DFLAGS) -fsanitize=address -fno-omit-frame-pointer $(EXECUTABLE).c core/*.c -o $(EXECUTABLE) $(LDFLAGS) &&) true
+        $(foreach       EXECUTABLE,$(EXECUTABLES),$(CC) $(CFLAGS) $(DFLAGS) -fsanitize=address -fno-omit-frame-pointer $(EXECUTABLE).c core/*.c -o $(EXECUTABLE) $(LDFLAGS) &&) true
 
 clean:
-	$(foreach EXECUTABLE,$(EXECUTABLES),rm -rf $(EXECUTABLE) &&) true
+        $(foreach EXECUTABLE,$(EXECUTABLES),rm -rf $(EXECUTABLE) &&) true
 
 .PHONY: all clean
+
+install:
+	$(foreach EXECUTABLE,$(EXECUTABLES),ln -sf $(shell pwd)/$(EXECUTABLE) /usr/local/bin/smarg-$(EXECUTABLE) &&) true
+
+uninstall:
+	$(foreach EXECUTABLE,$(EXECUTABLES),ln -rf $(shell pwd) /usr/local/bin/smarg-$(EXECUTABLE)) &&) true


### PR DESCRIPTION
* Removed static linking as it's less likely on modern systems that you'll have the archive files instead of the dynamic libraries
* Added -pipe to RFLAGS, will improve compile time, uses more RAM for compilation
* Added RFLAGS into LDFLAGS, I believe this is needed for the optimise options to be used correctly with -flto
* Added install, symbolic links to /usr/local/bin